### PR TITLE
initial population of docs template with Control Tower content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docs-book/output/*

--- a/docs-book/master_middleman/source/index.html.md.erb
+++ b/docs-book/master_middleman/source/index.html.md.erb
@@ -7,11 +7,10 @@
       <li class="panel span3">
         <a class="configure" href="engineerbetter-control-tower/index.html" id="engineerbetter-control-tower">
           <div class="prodname">
-            Your Service for PCF<br />(Beta)
+            Control Tower for Concourse<br />(Beta)
           </div>
         </a>
       </li>
       </ul>
   </div>
 </div>
-

--- a/docs-book/master_middleman/source/subnavs/engineerbetter-control-tower_subnav.erb
+++ b/docs-book/master_middleman/source/subnavs/engineerbetter-control-tower_subnav.erb
@@ -6,7 +6,7 @@
     <ul>
 
       <li>
-        <a id='home-nav-link' href="/engineerbetter-control-tower/index.html">YOUR-PRODUCT-NAME (Beta)</a>
+        <a id='home-nav-link' href="/engineerbetter-control-tower/index.html">Control Tower for Concourse (Beta)</a>
       </li>
 
       <li>
@@ -14,13 +14,27 @@
       </li>
 
       <li>
-        <a href="/engineerbetter-control-tower/installing.html">Installing and Configuring YOUR-PRODUCT-NAME</a>
+        <a href="/engineerbetter-control-tower/installing.html">Installing and Configuring Control Tower for Concourse</a>
       </li>
 
-      <li>
-        <a href="/engineerbetter-control-tower/using.html">Using YOUR-PRODUCT-NAME</a>
+      <li class="has_submenu">
+            <a href="/engineerbetter-control-tower/using.html">Using Control Tower for Concourse</a>
+            <ul>
+                <li><a href="/engineerbetter-control-tower/using/deployment.html">Deployment</a></li>
+                <li class="has_submenu"><a href="/engineerbetter-control-tower/using/operate/operations.html">Operations</a>
+                <ul>
+                  <li><a href="/engineerbetter-control-tower/using/operate/security_and_networking.html">Security and Networking</a>
+                  <li><a href="/engineerbetter-control-tower/using/operate/scaling.html">Scaling a deployment</a>
+                  <li><a href="/engineerbetter-control-tower/using/operate/iaas_cost_efficiency.html">Iaas Cost efficiency</a>
+                  <li><a href="/engineerbetter-control-tower/using/operate/upgrades.html">Upgrades and maintenance</a>
+                  <li><a href="/engineerbetter-control-tower/using/operate/monitoring.html">Monitoring</a>
+                  <li><a href="/engineerbetter-control-tower/using/operate/destroy.html">Destroy</a></li>
+                </ul>
+                </li>
+
+            </ul>
       </li>
 
-    </ul>
-  </div>
+
+      </div>
 </div><!--end of sub-nav-->

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -1,85 +1,58 @@
 ---
-title: YOUR-PRODUCT-NAME (Beta)
+title: Control Tower for Concourse (Beta)
 owner: Partners
 ---
 
 <strong><%= modified_date %></strong>
 
-**If this product is in beta, keep and edit the warning note below.**
 <p class="note warning">
-<strong>WARNING! </strong>
-The PRODUCT-NAME for PCF tile is currently in beta and is intended for evaluation and test purposes only. 
-Do not use this product in a PCF production environment.
+<strong>WARNING!</strong>
+The Control Tower for Concourse for PCF tile is currently in beta and is intended for evaluation and test purposes only.
 </p>
 
-**This topic begins with a brief description of what the product tile (e.g. Apigee Edge Service Broker for PCF) does, 
-whereas the Overview section below describes what the service itself (e.g. Apigee Edge) does. See below for an example.**
-
-This documentation describes the Apigee Edge Service Broker for Pivotal Cloud Foundry (PCF). The Apigee Edge Service 
-Broker for PCF enables developers to manage APIs for their PCF apps through the Apigee Edge management console.
-
-**Note**: This description will appear under **OVERVIEW** in the tile's listing on 
-[Pivotal Network](http://network.pivotal.io).
+<br>This documentation describes the Control Tower for Concourse (Control Tower) software.</br>
+Control Tower for Concourse is an opinionated CLI tool to easily deploy Concourse in a single command.
 
 ## <a id='overview'></a>Overview
 
-**The overview describes the service that your product offers to PCF developers. 
-Make sure to overview the features of the integration.
-Don't focus only on the overview of your product that is being integrated.
-See below for an example.**
-
-The Apigee Edge Service Broker for PCF registers a service broker with PCF and exposes its service plans on the 
-Marketplace. Developers can then create service plan instances using Apps Manager or the Cloud Foundry Command 
-Line Interface (cf CLI) and bind them to their apps.
-
-Creating an Apigee Edge for PCF service instance and binding it to an app creates an Apigee Edge API proxy that 
-handles requests for the app. This lets developers use the Apigee Edge management console to manage API request 
-handling between clients and the app.
-
-**Note**: This overview will appear under **OVERVIEW**, combined with the description above in the tile's listing on 
-[Pivotal Network](http://network.pivotal.io).
+The goal of Control Tower for Concourse is to be the world's easiest way to deploy and operate Concourse CI in production.
+In just one command you can deploy a new Concourse environment for your team, on either AWS or GCP.
+<br>Your `control-tower` deployment will update itself and self-heal, restoring the underlying VMs if needed.</br>
+Using the same command-line tool, you can do things like manage DNS, scale your environment, or manage firewall policy.
+<br>CredHub is provided for secrets management and Grafana for viewing your Concourse metrics.</br>
 
 ## <a id='features'></a>Key Features
 
-**Note**: This feature list will appear under **FEATURES** in the tile's listing on 
-[Pivotal Network](http://network.pivotal.io). 
-Make sure you list the key features of the tile (the integration). 
-We cannot accept a list of the key features of your product that we are integrating.
+Control Tower for Concourse includes the following key features:
 
-YOUR-PRODUCT-NAME includes the following key features:
-
-* Feature one
-* Feature two
-* Feature three
-
-
++ Deploys the latest version of Concourse CI on any region in AWS or GCP.
++ Manual update or automatic self-update.
++ Access your Concourse over https access by default, with auto-generated or self-provided cert.
++ Deploy on your own domain, if you have a zone in Route53 or Cloud DNS.
++ Scale your workers horizontally or vertically.
++ Scale your Concourse database.
++ Presents workers on a single public IP to simplify external security policy.
++ Database encryption enabled by default.
++ Includes Grafana metrics dashboard.
++ Includes CredHub for secret management.
++ Saves you money by using AWS spot or GCP preemptible instances where possible, restarting them when needed.
++ Idempotent deployment and operations.
++ Easy destroy and cleanup.
 
 ## <a id="snapshot"></a>Product Snapshot
 
-The following table provides version and version-support information about PRODUCT-NAME.
+The following table provides version and version-support information about Control Tower for Concourse.
 
 <table class="nice">
     <th>Element</th>
     <th>Details</th>
     <tr>
-        <td>Tile version</td>
-        <td>vYOUR-VERSION-NUMBER</td>
+        <td>Version</td>
+        <td>0.19.1</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>YOUR-RELEASE-DATE (Ex: July 1, 2019)</td>
-    </tr>
-    <tr>
-        <td>Software component version</td>
-        <td>YOUR-SOFTWARE-COMPONENT-VERSION-NUMBER</td>
-    </tr>
-    <tr>
-        <td>Compatible Ops Manager version(s)</td>
-        <td>YOUR-COMPATIBLE-OPS-MAN-VERSION (Ex. 2.2, 2.3, and 2.4)</td>
-    </tr>
-    <tr>
-        <td>Compatible Pivotal Application Service version(s)</td>
-        <td>YOUR-COMPATIBLE-PIVOTAL-APPLICATION-SERVICE-VERSION (Ex. 2.2, 2.3, and 2.4)</td>
+        <td>March 2019</td>
     </tr>
     <tr>
        <td>BOSH stemcell version</td>
@@ -87,36 +60,34 @@ The following table provides version and version-support information about PRODU
     </tr>
     <tr>
         <td>IaaS support</td>
-        <td>AWS?, Azure?, GCP?, OpenStack?, and vSphere?</td>
+        <td>AWS and GCP</td>
     </tr>
     <tr>
         <td>IPsec support?</td>
-        <td>[Yes or No]</td>
+        <td>No</td>
     </tr>
 </table>
 
 
 ## <a id="reqs"></a>Requirements
 
-**Provide any general or specific requirements, prerequisites, or dependencies here. 
-A general requirement might be something like, "An AppDynamics account." 
-A specific requirement might be something like, "Packaging Dependencies for Offline Buildpacks."**
+Control Tower for Concourse requires IaaS credentials with sufficient privileges to deploy a BOSH Director with supporting infrastructre, and Concourse itself.
 
-YOUR-PRODUCT-NAME has the following requirements:
 
-+ PREREQUISITE-1
 
-+ PREREQUISITE-2
 
 ## <a id="limitations"></a>Limitations
+Currently supported IaaS targets are:
 
-**List any known limitations.**
+- AWS
+- GCP
+
+Azure will be supported in a future release.
+
 
 ## <a id="feedback"></a>Feedback
 
 If you have a feature request, questions, or information about a bug, please email
-[Pivotal Cloud Foundry Feedback](mailto:cf-feedback@pivotal.io) list or send an email to YOUR-SUPPORT-EMAIL.
+[Pivotal Cloud Foundry Feedback](mailto:cf-feedback@pivotal.io) list or send an email to support@engineerbetter.com.
 
 ## <a id='license'></a>License
-
-**List any license information here.**

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -1,32 +1,42 @@
 ---
-title: Installing and Configuring YOUR-PRODUCT-NAME
+title: Installing and Configuring Control Tower for Concourse
 owner: Partners
 ---
 
+
 <strong><%= modified_date %></strong>
 
-This topic describes how to install and configure YOUR-PRODUCT-NAME.
+This topic describes how to install and configure Control Tower for Concourse.
 
-##<a id='install'></a> Install and Configure YOUR-PRODUCT-NAME
+##<a id='install'></a> Install and Configure Control Tower for Concourse
 
-To install the YOUR-PRODUCT-NAME file on the Ops Manager Installation Dashboard, do the following:
+To install the Control Tower for Concourse file on the Ops Manager Installation Dashboard, do the following:
 
-1. Download the product file from Pivotal Network.
+1. Download the binary file from Pivotal Network.
 
-1. Navigate to the Ops Manager Installation Dashboard and click **Import a Product** to upload the product file. 
+2. Install it into your `PATH`.
 
-1. Under the **Import a Product** button, click **+** next to the version number of YOUR-PRODUCT-NAME. 
-This adds the tile to your staging area.
+3. You can choose to rename the file at your convenience.</br>
+Please note that the name of the file you choose will be the same as the command ran against your deployments. For example:
 
-1. Click the newly added **YOUR-PRODUCT-NAME** tile.
+```sh
+$ control-tower deploy --iaas gcp <deployment-name>
+```
+if the binary is renamed `control-tower`, or</br>
 
-1. **This portion of the procedure should tell the users how to configure the newly added tile by
-walking them through the sections. Which fields should they fill out? What are the different
-checkboxes? Include relevant screenshots here.** 
+```sh
+$ ctwr deploy --iaas aws <deployment-name>
+```
+if the the binary is renamed `ctwr`, etc...
 
-1. Click **Save**.
 
-1. Return to the Ops Manager Installation Dashboard and click **Apply changes** to install YOUR-PRODUCT-NAME tile.
+4.Ensure correct local dependencies for bootstrapping a [BOSH VM](https://bosh.io/docs/cli-v2-install/#additional-dependencies).
 
-**If needed, include additional configuration information below. For example, maybe there are
-configuration options not required for installation but which could be useful for certain users.**
+##<a id='credentials'></a> Configure Credentials
+Use long lived credentials, and not temporary security credentials.
+
+- **AWS (one of the following):**<br>
+  - Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.<br>
+  - Credentials configured via `aws configure`, for example `[default]` profile in `~/.aws/credentials`.<br>
+- **GCP:**<br>
+  - `GOOGLE_APPLICATION_CREDENTIALS_CONTENTS` environment variables set to the path to a GCP credentials json file.

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -1,60 +1,21 @@
 ---
-title: Release Notes for YOUR-PRODUCT-NAME
+title: Release Notes for Control Tower for Concourse
 owner: Partners
 ---
 
 <strong><%= modified_date %></strong>
 
-**This topic should include the Release Notes for your product. For examples, see the 
-[GCP Service Broker Release Notes](http://docs.pivotal.io/gcp-sb/release-notes.html) or the 
-[ISS Knowtify Search Analytics Release Notes](http://docs.pivotal.io/knowtify/release.html).
-When you release a new version, add new release notes to this file, keeping the older notes below.**
+These are release notes for Control Tower for Concourse.
 
-These are release notes for YOUR-PRODUCT-NAME.
+##<a id="ver"></a> v0.2.0
 
-##<a id="ver"></a> vCURRENT-VERSION-NUMBER (Ex. v1.0.1)
-
-**Release Date:** RELEASE-DATE (Ex. October 1, 2017)
+**Release Date:** 14/03/2019
 
 Features included in this release:
 
-* Feature one.
-* Feature two.
-* Feature three.
+* Concourse 5.0 Support
+* IaaS selection is now mandatory
 
 Fixed issues in this release:
 
-* Fixed issue one.
-* Fixed issue two.
-* Fixed issue three.
-
-**When you have fixed issue, you should have a corresponding known issue in the release below.**
-
-Known issues in this release:
-
-* Issue one.
-* Issue two.
-* Issue three.
-
-
-##<a id="ver"></a> vPREVIOUS-VERSION-NUMBER (Ex. v1.0.0)
-
-**Release Date:** RELEASE-DATE (Ex. August 1, 2017)
-
-Features included in this release:
-
-* Feature one.
-* Feature two.
-* Feature three.
-
-Fixed issues in this release:
-
-* Fixed issue one.
-* Fixed issue two.
-* Fixed issue three.
-
-Known issues in this release:
-
-* Issue one.
-* Issue two.
-* Issue three.
+* A bug which prevented workers in a GCP deployment from reaching Credhub or the UAA

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -1,17 +1,12 @@
 ---
-title: Using YOUR-PRODUCT-NAME
+title: Using Control Tower for Concourse
 owner: Partners
 ---
 
 <strong><%= modified_date %></strong>
 
-This topic describes how to use YOUR-PRODUCT-NAME.
+This section describes how to use Control Tower for Concourse (Control Tower).
 
-##<a id='using'></a> Using YOUR-PRODUCT-NAME
+The Deployment section covers 'Day 1' deployment concerns, required for initial creation of a new Concourse.
 
-**This topic should include any instructions for how to use the service or dashboard created by the tile. 
-Give procedures for how to perform the different functions offered by your product and provide screenshots where necessary.** 
-
-**You can also use this section to include information about Architecture and Troubleshooting for known errors. 
-If you include a Troubleshooting section, follow the Symptom/Explanation format used in the 
-[Okta Troubleshooting](http://docs.pivotal.io/p-identity/okta/troubleshooting.html) topic**.
+The Operations section covers 'Day 2' operational concerns and advanced topics relating to networking, security, scaling and monitoring.

--- a/docs-content/using/deployment.html.md.erb
+++ b/docs-content/using/deployment.html.md.erb
@@ -1,0 +1,211 @@
+---
+title: Deployment
+owner: Partners
+---
+
+##<a id='Quickstart Deploy'></a>Quickstart Deploy
+
+Deploy a new Concourse with:
+
+```sh
+$ control-tower deploy --iaas <iaas-provider> <your-project-name>
+```
+
+For example:
+
+```sh
+$ control-tower deploy --iaas aws my-ci
+
+...
+DEPLOY SUCCESSFUL. Log in with:
+fly --target ci login --insecure --concourse-url https://10.0.0.0 --username  --password
+
+Metrics available at https://10.0.0.0:3000 using the same username and password
+
+Log into credhub with:
+eval "$(control-tower info my-ci --env)"
+```
+
+A new deploy from scratch takes approximately 20 minutes.
+
+##<a id='Define a name'></a>Define a name
+
+**Deployment name**</br>
+
+Is defined during initial deployment:</br>
+
+```sh
+$ control-tower deploy --iaas gcp my-ci
+```
+Needs to be used for any subsequent `control-tower` calls against the same deployment.
+
+**Character limit**</br>
+11 characters.
+
+##<a id='IaaS Provider Support'></a>IaaS Provider Support
+
+**Choosing an IaaS**</br>
+
+Supported IaaS providers:
+
+- Amazon Web Services
+- Google Cloud Platform
+
+To choose an IaaS provider, use the `--iaas` flag.</br>
+
+**The `--iaas` flag is required for all commands.**
+
+Allowed values:
+
+- `gcp`
+- `aws`
+
+For example:
+
+```sh
+$ control-tower deploy --iaas gcp my-ci
+```
+Or set `[$IaaS]` environment variable to `value`
+
+For example:
+
+```sh
+$ export IAAS=AWS
+```
+
+**IaaS User Permissions**</br>
+
+If you would like to run Control Tower with its own user account, create a user with the following permissions
+
+| Using a dedicated AWS IAM account |
+|------------------------------------|
+|![](http://i.imgur.com/Q0mOUjv.png)|
+
+
+| Using a dedicated GCP IAM member |
+|----------------------------------|
+|An IAM Primitive role of `roles/owner` for the target GCP Project is required.|
+
+##<a id='Choosing a region'></a>Choosing a region
+
+**Define region (Global flag)**</br>
+AWS or GCP region (default: “eu-west-1” on AWS and “europe-west1” on GCP) `[$AWS_REGION]`</br>
+To define a region, use the `--region` flag:
+
+```sh
+$ control-tower deploy --iaas gcp --region eu-west-2 my-ci
+```
+
+**Define zone**</br>
+Specify an availability zone `[$ZONE]` (cannot be changed after the initial deployment).</br>
+To define a zone, use the `--zone` flag:
+
+```sh
+$ control-tower deploy --iaas gcp --region eu-west-2 --zone eu-west-2b my-ci
+```
+
+##<a id='Deployment Namespace'></a>Deployment Namespace
+
+**Namespace**
+**(Global flag)**</br>
+Using a namespace allows you to group your deployments using a meaningful name.
+
+The namespace is used as part of the configuration bucket name `[$NAMESPACE]`.</br>
+Use any valid string that provides a meaningful namespace of the deployment.</br>
+The flag is `--namespace value` and can be used like below:</br>
+
+```sh
+$ control-tower deploy --namespace <namespace> --iaas gcp my-ci
+```
+
+&rightarrow; Note: if `--namespace` has been provided in the initial `deploy`, it will be required for any subsequent `control-tower` calls against the same deployment.
+
+##IaaS Resource tagging
+
+**VM tagging**
+
+Add a tag/label to the BOSH VMs that form your `control-tower` deployment. Can be used multiple times in a single deploy command.</br>
+Use the `--add-tag key=value` command:
+
+```sh
+$ control-tower deploy --iaas aws --add-tag worker=<my-worker> my-ci
+```
+
+
+##<a id='Using a custom domain'></a>Using a custom domain
+
+If you have a DNS zone configured in AWS Route53 or GCP CloudDNS, you can use this for your deployment.
+
+Domain to use as endpoint for Concourse web interface (eg: ci.myproject.com).
+
+To define a custom domain, use the `--domain` flag or set the `$DOMAIN` environment variable:
+
+```sh
+$ control-tower deploy --domain chimichanga.engineerbetter.com my-ci
+```
+In the example above `control-tower` will search for a hosted zone that matches chimichanga.engineerbetter.com or engineerbetter.com and add a record to the longest match (chimichanga.engineerbetter.com in this example).
+
+##<a id='User Authentication Configuration'></a>User Authentication Configuration
+Users can choose to configure authentication against their concourses via GitHub.
+
+- `--github-auth-client-id value`:</br>
+Client ID for a github OAuth application.</br>
+Used for Github Auth `[$GITHUB_AUTH_CLIENT_ID]`
+
+- `--github-auth-client-secret value`:</br>
+Client Secret for a github OAuth application.<br>
+Used for Github Auth `[$GITHUB_AUTH_CLIENT_SECRET]`.
+
+-------------------------------------------------------------
+
+##<a id='Deployment Infrastructure'></a>Deployment Infrastructure
+
+`control-tower` first creates an S3 or GCS bucket to store its own configuration and saves a `config.json` file there. It then uses Terraform to deploy the following infrastructure:
+
+|AWS                              |
+|------------------------------- |
+|Key pair |
+|S3 bucket for the blobstore|
+|IAM user that can access the blobstore with:|
+| - IAM access key + IAM user policy|
+|IAM user that can deploy EC2 instances:|
+|IAM access key + IAM user policy|
+|VPC|
+|Internet gateway|
+|Route for internet_access|
+|NAT gateway|
+|Route table for private|
+|Subnet for public|
+|Subnet for private|
+|Route table association for private|
+|Route53 record for Concourse|
+|EIP for director, ATC, and NAT|
+|Security groups for director, vms, RDS, and ATC|
+|Route table for RDS|
+|Route table associations for RDS|
+|Subnets for RDS|
+|DB subnet group|
+|DB instance|
+
+|GCP         |
+|------------|
+|DNS|
+|Record pointing to the ATC IP|
+|Compute route for the nat instance|
+|Compute instance for the nat|
+|Compute network|
+|Public and Private Compute subnetworks|
+|Compute firewalls for director, nat, atc-one, atc-two, vms, atc-three, internal, and sql|
+|Service account for for BOSH|
+|Service account key for BOSH|
+|Project iam member for BOSH|
+|Compute addresses for the ATC and Director|
+|Sql database instance|
+|Sql database|
+|Sql user|
+
+Once the terraform step is complete, `control-tower` deploys a BOSH director on an t2.small/n1-standard-1 instance, and then uses that to deploy a Concourse with the following settings:
+
+- One t2.small/n1-standard-1 for the Concourse web server
+- One m4.xlarge [spot](https://aws.amazon.com/ec2/spot/)/n1-standard-4 [preemptible](https://cloud.google.com/preemptible-vms/) instance used as a Concourse worker
+- Access via over HTTP and HTTPS using a user-provided certificate, or an auto-generated self-signed certificate if one isn't provided.

--- a/docs-content/using/operate/destroy.html.md.erb
+++ b/docs-content/using/operate/destroy.html.md.erb
@@ -1,0 +1,12 @@
+---
+title: Using Control Tower for Concourse
+owner: Partners
+---
+
+### Destroy
+
+To destroy your Concourse:
+
+```sh
+$ control-tower destroy --iaas <iaas-provider> <your-project-name>
+```

--- a/docs-content/using/operate/iaas_cost_efficiency.html.md.erb
+++ b/docs-content/using/operate/iaas_cost_efficiency.html.md.erb
@@ -1,0 +1,68 @@
+---
+title: Iaas Cost Efficiency
+owner: Partners
+---
+
+##<a id='Improve Cost Efficiency'></a>Improve Cost Efficiency
+
+Choose the best type of instances to cater to your needs.
+
+- On AWS
+  - `--spot=value`</br>
+    You can choose your Concourse workers to be set as spot instances. Can be true/false. (Default is true.)
+
+    > Control Tower uses spot instances for workers as a cost saving measure. Users requiring lower risk may switch this feature off by setting `--spot=false`.</br>
+
+- On GCP
+  - `--preemptible=value`</br>
+      You can choose your Concourse workers to be set as preemptible instances. Can be true/false. (Default is true.)
+
+  <p class="note warning"><strong>WARNING</strong>: Be aware the [preemptible instances](https://cloud.google.com/preemptible-vms/) _will_ go down at least once every 24 hours so deployments with only one worker _will_ experience downtime with this feature enabled. BOSH will ressurect falled workers automatically.</p>
+
+`spot` and `preemptible` are interchangeable so if either of them is set to false then interruptible instances will not be used regardless of your IaaS. i.e:<br>
+
+- Results in an AWS deployment using non-spot workers:
+
+```sh
+$ control-tower deploy --spot=true --preemptible=false <your-project-name>
+```
+- Results in an AWS deployment using non-spot workers:
+
+```sh
+$ control-tower deploy --preemptible=false <your-project-name>
+```
+- Results in a GCP deployment using non-preemptible workers:
+
+```sh
+$ control-tower deploy --iaas gcp --spot=false <your-project-name>
+```
+
+##<a id='Estimated Costs'></a>Estimated Costs
+
+By default, Control Tower deploys to the AWS `eu-west-1` (Ireland) region or the GCP `europe-west1` (Belgium) region, and uses spot instances for large and xlarge Concourse VMs.</br>
+The estimated monthly cost is as follows:
+
+#### AWS
+
+| Component     | Size             | Count | Price (USD) |
+|---------------|------------------|-------|------------:|
+| BOSH director | t2.small         |     1 |       18.30 |
+| Web Server    | t2.small         |     1 |       18.30 |
+| Worker        | m4.xlarge (spot) |     1 |      ~50.00 |
+| RDS instance  | db.t2.small      |     1 |       28.47 |
+| NAT Gateway   |         -        |     1 |       35.15 |
+| gp2 storage   | 20GB (bosh, web) |     2 |        4.40 |
+| gp2 storage   | 200GB (worker)   |     1 |       22.00 |
+| **Total**     |                  |       |  **176.62** |
+
+#### GCP
+
+| Component     | Size                              | Count | Price (USD) |
+|---------------|-----------------------------------|-------|------------:|
+| BOSH director | n1-standard-1                     |     1 |       26.73 |
+| Web Server    | n1-standard-1                     |     1 |       26.73 |
+| Worker        | n1-standard-4 (preemptible)       |     1 |       32.12 |
+| DB instance   | db-g1-small                       |     1 |       27.25 |
+| NAT Gateway   | n1-standard-1                     |     1 |       26.73 |
+| disk storage  | 20GB (bosh, web) + 200GB (worker) |   -   |       40.80 |
+| **Total**     |                                   |       |  **180.35** |

--- a/docs-content/using/operate/monitoring.html.md.erb
+++ b/docs-content/using/operate/monitoring.html.md.erb
@@ -1,0 +1,37 @@
+---
+title: Monitoring
+owner: Partners
+---
+
+
+##<a id='Metrics'></a>Metrics
+
+
+Control Tower now automatically deploys Influxdb, Riemann, and Grafana on the web node. You can access Grafana on port 3000 of your regular concourse URL using the same username and password as your Concourse admin user. We put in a default dashboard that tracks:</b>
+Build times, CPU usage, Containers, Disk usage.
+
+
+
+
+##<a id='Info'></a>Info
+
+
+- To fetch information about your Control Tower deployment:
+
+```sh
+$ control-tower info --json <your-project-name>
+```
+
+- To load credentials into your environment from your Control Tower deployment:
+
+```sh
+$ eval "$(control-tower info --env <your-project-name>)"
+```
+
+- To check the expiry of the BOSH Director's NATS CA certificate:
+
+```sh
+$ control-tower info --cert-expiry <your-project-name>
+```
+
+  <p class="note warning"><strong>WARNING</strong>: If your deployment is approaching a year old, it may stop working due to expired certificates. For information please see this issue https://github.com/EngineerBetter/concourse-up/issues/81.

--- a/docs-content/using/operate/operations.html.md.erb
+++ b/docs-content/using/operate/operations.html.md.erb
@@ -1,0 +1,12 @@
+---
+title: Operations
+owner: Partners
+---
+
+<strong><%= modified_date %></strong>
+
+Operational steps
+
+
++ Security and networking
++ Monitor and self-update

--- a/docs-content/using/operate/scaling.html.md.erb
+++ b/docs-content/using/operate/scaling.html.md.erb
@@ -1,0 +1,93 @@
+---
+title: Scaling a Deployment
+owner: Partners
+---
+
+##<a id='Scaling Workers'></a>Scaling Workers
+
+- Change instance type</br>
+  - `--worker-type`</br>
+  Specify a worker **type** for AWS (m5 or m4) (default: "m4") `[$WORKER_TYPE]` (see comparison table below). **Note: this is an AWS-specific option**
+
+    > AWS does not offer m5 instances in all regions, and even for regions that do offer m5 instances, not all zones within that region may offer them. To complicate matters further, each AWS account is assigned AWS zones at random - for instance, `eu-west-1a` for one account may be the same as `eu-west-1b` in another account. If m5s are available in your chosen region but _not_ the zone Control Tower has chosen, create a new deployment, this time specifying another `--zone`.
+
+- Scale horizontally<br>
+  - `--workers value`</br>
+    Choose the **number** of Concourse workers to deploy (default: 1) `[$WORKERS]`.</br>
+    For example:
+
+    ```sh
+    $ control-tower deploy --workers 2 <deployment-name>
+    ```
+
+- Scale vertically</br>
+  - `--worker-size value`</br>
+    Choose the **size** of Concourse workers to deploy.</br>
+    Can be medium, large, xlarge, 2xlarge, 4xlarge, 10xlarge, 12xlarge, 16xlarge or 24xlarge depending on the worker-type (see above) (default: "xlarge") `[$WORKER_SIZE]`.</br>
+    For example:
+
+    ```sh
+    $ control-tower deploy --worker-size large <deployment-name>
+    ```
+- Instance type reference table:</br>
+
+    | --worker-size | AWS m4 Instance type | AWS m5 Instance type* | GCP Instance type |
+    |---------------|----------------------|-----------------------|-------------------|
+    | medium        | t2.medium            | t2.medium             | n1-standard-1     |
+    | large         | m4.large             | m5.large              | n1-standard-2     |
+    | xlarge        | m4.xlarge            | m5.xlarge             | n1-standard-4     |
+    | 2xlarge       | m4.2xlarge           | m5.2xlarge            | n1-standard-8     |
+    | 4xlarge       | m4.4xlarge           | m5.4xlarge            | n1-standard-16    |
+    | 10xlarge      | m4.10xlarge          |                       | n1-standard-32    |
+    | 12xlarge      |                      | m5.12xlarge           |                   |
+    | 16xlarge      | m4.16xlarge          |                       | n1-standard-64    |
+    | 24xlarge      |                      | m5.24xlarge           |                   |
+
+    \* _m5 instances not available in all regions and all zones. See `--worker-type` for more info._
+
+
+##<a id='Scaling Web Node'></a>Scaling Web Node
+
+- Scale vertically</br>
+
+  - `--web-size value`</br>
+  Choose the size of the Concourse web node. Can be small, medium, large, xlarge, 2xlarge (default: "small") `[$WEB_SIZE]`.</br>
+  For example:
+
+```sh
+$ control-tower deploy --web-size medium <deployment-name>
+```
+
+- Instance type reference table:</br>
+
+| --web-size | AWS Instance type | GCP Instance type |
+|------------|-------------------|-------------------|
+| small      | t2.small          | n1-standard-1     |
+| medium     | t2.medium         | n1-standard-2     |
+| large      | t2.large          | n1-standard-4     |
+| xlarge     | t2.xlarge         | n1-standard-8     |
+| 2xlarge    | t2.2xlarge        | n1-standard-16    |
+
+
+##<a id='Scaling the Database'></a>Scaling the Database
+
+  - `--db-size value`</br>
+Scale the database vertically by choosing the size of Concourse Postgres instance. Can be small, medium, large, xlarge, 2xlarge, or 4xlarge (default: "small") `[$DB_SIZE]`.</br>
+For example:
+
+```sh
+$ control-tower deploy --db-size medium <deployment-name>
+```
+
+  > Note that when changing the database size on an existing Control Tower deployment, the SQL instance will scaled by terraform resulting in approximately 3 minutes of downtime.<br>
+
+- Database size reference table:</br>
+
+| --db-size | AWS Instance type | GCP Instance type  |
+|-----------|-------------------|--------------------|
+| small     | db.t2.small       | db-g1-small        |
+| medium    | db.t2.medium      | db-custom-2-4096   |
+| large     | db.m4.large       | db-custom-2-8192   |
+| xlarge    | db.m4.xlarge      | db-custom-4-16384  |
+| 2xlarge   | db.m4.2xlarge     | db-custom-8-32768  |
+| 4xlarge   | db.m4.4xlarge     | db-custom-16-65536 |

--- a/docs-content/using/operate/security_and_networking.html.md.erb
+++ b/docs-content/using/operate/security_and_networking.html.md.erb
@@ -1,0 +1,102 @@
+---
+title: Security and Networking
+owner: Partners
+---
+
+##<a id='Configuring SSL Certificates'></a>Configuring SSL Certificates
+
+Deployed Concourses can be accessed via over HTTPS using a
+user-provided certificate, or an auto-generated self-signed certificate
+if one isn't provided.
+
+**Without custom domain name**
+
+If a custom domain is not used,`control-tower` will generate a self-signed certificate.
+
+
+**With custom domain name**
+
+  - Automatically generated certificates</br>
+    By default control-tower will generate a self-signed certificate using the given domain.</br>
+  - User-provided certificates</br>
+    Pass the cert and private key as strings using:</br>
+      `--tls-cert value`:TLS cert to use with Concourse endpoint `[$TLS_CERT]`</br>
+      `--tls-key value`:TLS private key to use with Concourse endpoint `[$TLS_KEY]`</br>
+
+For example:
+
+```sh
+$ control-tower deploy \
+  --domain chimichanga.engineerbetter.com \
+  --tls-cert "$(cat chimichanga.engineerbetter.com.crt)" \
+  --tls-key "$(cat chimichanga.engineerbetter.com.key)" \
+  my-ci
+```
+
+
+
+##<a id='Data Encryption'></a>Data Encryption
+
+**Database Encryption**
+
+Database encryption is enabled by default.
+
+**Volume Encryption**
+
+On AWS, EBS volumes are encypted by default.
+
+
+
+##<a id='Network Security'></a>Network Security
+
+**Persistent public IP**
+
+Concourse workers are accessible on a single public IP to simplify external security policy.</br>
+
+**Configuring trusted networks**
+
+Control Tower normally allows incoming traffic from any address to reach your web node. You can use the `--allow-ips` flag to add firewall rules to prevent this or set `$ALLOW_IPS` environment variable.
+
+This option takes a comma separated list of values. The default is "0.0.0.0/0".
+
+```sh
+$ control-tower deploy --iaas gcp --allow-ips 0.0.0.0/0 <deployment-name>
+```
+Note: `allow-ips` governs what can access Concourse but not what can access the control plane (i.e. the BOSH director).
+
+To allow traffic from your local machine only, use the command:
+
+```sh
+$ control-tower deploy --allow-ips $(dig +short myip.opendns.com@resolver1.opendns.com) --iaas gcp <deployment-name>
+```
+
+##<a id='Deploying to custom network ranges'></a>Deploying to custom network ranges
+
+Choose custom IP ranges for a concourse's network, created at deploy time.
+
+**Warning: network ranges cannot be changed after initial deployment.**
+
+You can use the flags below to customise the range of each part of the subnet:
+
+- `--vpc-network-range value`:</br>
+Customise the VPC network CIDR to deploy into (required for AWS)`[$VPC_NETWORK_RANGE]`
+- `--public-subnet-range value`:</br>
+Customise public network CIDR (if IAAS is AWS must be within --vpc-network-range) (required)`[$PUBLIC_SUBNET_RANGE]`</br>
+- `--private-subnet-range value`:</br>
+Customise private network CIDR (if IAAS is AWS must be within --vpc-network-range) (required)`[$PRIVATE_SUBNET_RANGE]`</br>
+- `--rds-subnet-range1 value`:</br>
+Customise first rds network CIDR (must be within --vpc-network-range) (required for AWS)`[$RDS_SUBNET_RANGE1]`</br>
+- `--rds-subnet-range2 value`:</br>
+Customise second rds network CIDR (must be within --vpc-network-range) (required for AWS)`[$RDS_SUBNET_RANGE2]`
+
+  > All the ranges above should be in the CIDR format of IPv4/Mask. The sizes can vary as long as vpc-network-range is big enough to contain all others (in case IAAS is AWS). The smallest CIDR for public and private subnets is a /28. The smallest CIDR for rds1 and rds2 subnets is a /29.
+
+##<a id='Credential Management'></a>Credential Management
+
+Control Tower deploys the [credhub](https://github.com/cloudfoundry-incubator/credhub) service alongside Concourse and configures Concourse to use it.</br>
+More detail on how credhub integrates with Concourse can be found [here](https://concourse-ci.org/creds.html).</br>
+You can log into credhub by running:</br>
+
+```sh
+$ eval "$(control-tower info --env --region $region $deployment)"
+```

--- a/docs-content/using/operate/upgrades.html.md.erb
+++ b/docs-content/using/operate/upgrades.html.md.erb
@@ -1,0 +1,36 @@
+---
+title: Upgrades and Maintenance
+owner: Partners
+---
+
+##<a id='Automatic Upgrade'></a>Automatic Upgrade
+
+When Control Tower deploys Concourse, it now adds a pipeline to the new Concourse called `control-tower-self-update`.</br>
+This pipeline continuously monitors our Github repo for new releases and updates Concourse in place whenever a new version of Control Tower comes out.
+This pipeline is paused by default, so just unpause it in the UI to enable the feature.
+
+
+##<a id='Manual Upgrade'></a>Manual Upgrade
+
+To upgrade your Concourse manually, download the new binary from Pivotal Network and run `control-tower deploy <your-project-name>` again.
+
+##<a id='Rotating NATS certificates'></a>Rotating NATS certificates
+
+- Rotation
+  - `--renew-nats-cert`</br>
+  Allows you to rotate the NATS certificate on the director</br>
+  <p class="note warning"><strong>WARNING</strong>: Note that the NATS certificate [is hardcoded to expire after 1 year](https://github.com/cloudfoundry/bosh-cli/blob/master/vendor/github.com/cloudfoundry/config-server/types/certificate_generator.go#L171). This command follows [the instructions on bosh.io](https://bosh.io/docs/nats-ca-rotation/) to rotate this certificate. **This operation _will_ cause downtime on your Concourse** as it performs multiple full recreates.</p>
+
+- Stage monitoring
+    - `--stage value`</br>
+    Specify a specific stage at which to start the NATS certificate renewal process. If not specified, the stage will be determined automatically.
+
+    - Certificate rotation stage reference table:
+
+| Stage | Description |
+|-------|-------------|
+| 0     | Adding new CA (create-env) |
+| 1     | Recreating VMs for the first time (recreate) |
+| 2     | Removing old CA (create-env) |
+| 3     | Recreating VMs for the second time (recreate) |
+| 4     | Cleaning up director-creds.yml |

--- a/docs-layout/source/layouts/_header.erb
+++ b/docs-layout/source/layouts/_header.erb
@@ -35,7 +35,7 @@
   <% if current_page.data.title %> <%# this is a proxy for if !homepage %>
     <header class="header header-layout">
       <h1 class="logo">
-        <a href="/"><%= vars.book_title || 'Default Book Title' %></a>
+        <a href="/"><%= vars.book_title || 'Control Tower for Concourse' %></a>
       </h1>
       <%= yield_for_archive_drop_down_menu %>
       <%# @TODO: Replace with dynamic versioning %>


### PR DESCRIPTION
change the structure of the subnav and add 4 more categories to the using section in the docs-content

reorganise the 4 subcategories for the using section, strongly inspired by our readme but with some tweaks to make sense of the user flow, with a focus on the deploy section for this commit

reorganise the operate section, such as adding more headers to explain the different parts of the user flow. In progress

add a collapsible with arrow for the Using category with the 4 subcategories covering the user journey

add a section in the deploy category to talk about what happens when deploying, in the shape of 2 tables for each IaaS

move the content about getting deployment info to the top of the page

shorten the headers and titles

restructure of the using section in progress, add 2 subsections to the operate category, now need to edit those as well as fixing the invisible deploy category, now disappeared because restructure in progress

structure menu correctly

Put deploy at the top of the page

move credentials config to install section

fix broken link for using ctwr top level menu

add an index file for operation section and content at top of file

Make IaaS provider support more clearly explained

Define a clear IaaS User Permission section

Add more categories to the deploy page, make them match the mind map and add an anchor tag to make them clickable at the top of the page

finalise this deploy page by adding a custom metadata and namespace section, anchored as well

add a section about data protection while in transit or at rest, add a section about security and networking to talk about allow ips and cidr range, add 2 more sections at the bottom of the page to talk about the credentials management, last section about authentication in progress

remove the github auth section as it should be movedto part 2 of the operation category, to match the mind map exactly. Also reformulate the IP range section with allow-ips flag

add one more sentence to explain what the CIDR block is

add a section about the concourse workers persistent public IP. The security and networking section should now mirror what is in our mindmap

add 2 full stops that were missing

add a section at the top about github auth config

add the resource cost monitoring section at the bottom, with a subsection about cost efficiency improvement and another subsection about estimated cost

add a section at the top about worker config

add a section about scaling web nodes vertically

rearrange the configure worker nodes section

finalise the structure on VM config

add a section about patch and global updates

add a category about nats certs rotation, add 2 warning section about downtime caused by upgrades

add a sentence under the improve cost efficiency category

add a few tweaks to the deploy section, notably replacing cup to ctwr when needed, but also ensuring consistency within all flags

replace concourse-up commands to ctwr and making the section about data protection in transit more visually pleasing with better bulleted list

just change the command to run credhub at bottom of page to be consistent with the rest of the commands

resize the subtitles and restructure the nats certs rotation section

mostly add the last section at bottom, about how to get metrics and info

move the github auth to deploy section

rename the deployment file and change the subnav

make deployement section titles more helpful

rename operations section and in the subnav menu

make security networking titles more useful

created scaling section with rename in subnav

restructure operations content

add sections to operations to cover upgrades and monitoring

move the NATs certs section from Scaling file to Monitoring file

push changes about monitoring section:removing the nats certs from the scaling section

add a new file to cover iaas costs in operate section, and add it in the subnav

rename the title of the iaas cost efficiency in the subnave to match the file itself

add detail to installation section about being bale to rename the binary and use of the command as a consequence. Make bottom bulleted list better

Make warning more succinct

Tighten up Requirements and Limitations

Expand on privilige requirements

Explain docs structure

replace to control-tower

replace ctwr to control-tower in the deployment section

replace ctwr to control-tower in the security and networking section

replace ctwr for control-tower in deployment scaling section

replace ctwr to control-tower for the IaaS cost efficiency section

replace ctwr to control-tower for the upgrades section

replace ctwr to control-tower for the monitoring section

replace the ctwr command for control-tower in the destroy section

change the format of commands for consistency so that bnow they appear like in a bash shell

change the release date in the product snapshot of the intro/landing page to March

add iaas flag + change the example commands in install section

rearrange a few things in the deployment section, such as the commands, but also add an image for AWS IAM account permissions table

change the commands to make them look like they are in a bash shell for consistency

change the commands to make them look like they are in a bash shell for consistency

add an example for the db size scaling for consistency

make commands look consistent from the rest of the documentation

change the look of the commands in the section about renaming the binary

--iaas is not optional

make commands look consistent and make them look like they are in a shell

show how to use the environment variable instead of a flag

add missing title to instance type reference table for document consistency

create release notes

add gitignore